### PR TITLE
business lines in api

### DIFF
--- a/lib/adyen/services/legal_entity_management.rb
+++ b/lib/adyen/services/legal_entity_management.rb
@@ -70,5 +70,15 @@ module Adyen
 
       @client.call_adyen_api(@service, action, {}, {}, @version)
     end
+
+    def create_business_line(request)
+      @client.call_adyen_api(@service, "businessLines", request, {}, @version)
+    end
+
+    def get_business_line(business_line_id)
+      action = { method: 'get', url: "businessLines/" + business_line_id }
+
+      @client.call_adyen_api(@service, action, {}, {}, @version)
+    end
   end
 end

--- a/spec/legal_entity_management_spec.rb
+++ b/spec/legal_entity_management_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Adyen::LegalEntityManagement, service: "Legal entity management s
   test_sets = [
     ["create_legal_entity", "id", "LE322KH223222D5DNL6HZ8RFV"],
     ["create_transfer_instrument", "id", "SE322JV223222D5DNVKPZ3GL7"],
-    ["create_document", "id", "SE322JV223222D5DTMZBK44M5"]
+    ["create_document", "id", "SE322JV223222D5DTMZBK44M5"],
+    ["create_business_line", "id", "SE322JV223222D5FKLGQPC2H5"]
   ]
 
   context "legal entities"do
@@ -210,6 +211,32 @@ RSpec.describe Adyen::LegalEntityManagement, service: "Legal entity management s
         to eq(204)
       expect(response_hash).
         to eq("")
+    end
+  end
+
+  context "business lines" do
+    it "gets a business line" do
+      line_id = "SE322JV223222D5FKLGQPC2H5"
+
+      response_body = json_from_file("mocks/responses/LegalEntityManagement/get_business_line.json")
+
+      url = client.service_url("LegalEntityManagement", "businessLines/#{line_id}", "1")
+      WebMock.stub_request(:get, url).
+      to_return(
+        body: response_body
+      )
+
+      result = client.legal_entity_management.get_business_line(line_id)
+      response_hash = result.response
+
+      expect(result.status).
+        to eq(200)
+      expect(response_hash).
+        to eq(JSON.parse(response_body))
+      expect(response_hash).
+        to be_a Adyen::HashWithAccessors
+      expect(response_hash).
+        to be_a_kind_of Hash
     end
   end
 

--- a/spec/mocks/requests/LegalEntityManagement/create_business_line.json
+++ b/spec/mocks/requests/LegalEntityManagement/create_business_line.json
@@ -1,0 +1,15 @@
+{
+  "capability": "receivePayments",
+  "industryCode": "55",
+  "webData": [
+    {
+      "webAddress": "https://www.adyen.com"
+    }
+  ],
+  "legalEntityId": "LE322KT223222D5FJ7THR293F",
+  "sourceOfFunds": {
+    "type": "business",
+    "adyenProcessedFunds": "false",
+    "description": "Funds from my flower shop business"
+  }
+}

--- a/spec/mocks/responses/LegalEntityManagement/create_business_line.json
+++ b/spec/mocks/responses/LegalEntityManagement/create_business_line.json
@@ -1,0 +1,16 @@
+{
+  "capability": "receivePayments",
+  "industryCode": "55",
+  "legalEntityId": "LE322KH223222D5FJHXVQBW3Q",
+  "sourceOfFunds": {
+    "adyenProcessedFunds": "false",
+    "description": "Funds from my flower shop business",
+    "type": "business"
+  },
+  "webData": [
+    {
+      "webAddress": "https://www.adyen.com"
+    }
+  ],
+  "id": "SE322JV223222D5FKLGQPC2H5"
+}

--- a/spec/mocks/responses/LegalEntityManagement/get_business_line.json
+++ b/spec/mocks/responses/LegalEntityManagement/get_business_line.json
@@ -1,0 +1,23 @@
+{
+  "capability": "string",
+  "id": "SE322JV223222D5FKLGQPC2H5",
+  "industryCode": "55",
+  "legalEntityId": "LE322KT223222D5FJ7THR293F",
+  "salesChannels": [
+    "string"
+  ],
+  "sourceOfFunds": {
+    "acquiringBusinessLineId": "string",
+    "type": "business",
+    "adyenProcessedFunds": "true",
+    "description": "Funds from my flower shop business"
+  },
+  "webData": [
+    {
+      "webAddress": "string"
+    }
+  ],
+  "webDataExemption": {
+    "reason": "noOnlinePresence"
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,8 @@ def create_test(client, service, method_name, parent_object)
       action = "transferInstruments"
     elsif action.include?("Document")
       action = "documents"
+    elsif action.include?("BusinessLine")
+      action = "businessLines"
     end
   end
 


### PR DESCRIPTION
**Description**
We voegen de business lines call toe aan de API zodat we deze kunnen gebruiken in de applicatie

**Tested scenarios**
Aanmaken en het opvragen van de business lines via mocking conform API v2.

**Fixed issue**:  [T22002](https://phabricator.moneybird.net/T22002) (gem gedeelte)
