### PR TITLE
fix disputes naming bug

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -69,7 +69,7 @@ module Adyen
         when 'PosTerminalManagement'
           url = "https://postfmapi-#{@env}.adyen.com/postfmapi/terminal"
           supports_live_url_prefix = false
-        when 'DataProtectionService', 'DisputesService'
+        when 'DataProtectionService', 'DisputeService'
           url = "https://ca-#{@env}.adyen.com/ca/services/#{service}"
           supports_live_url_prefix = false
         when "AccessControlServer"

--- a/lib/adyen/services/disputes.rb
+++ b/lib/adyen/services/disputes.rb
@@ -5,7 +5,7 @@ module Adyen
 
     DEFAULT_VERSION = 30
     def initialize(client, version = DEFAULT_VERSION)
-      super(client, version, 'DisputesService')
+      super(client, version, 'DisputeService')
     end
 
     def accept_dispute(request, headers: {})

--- a/lib/adyen/services/disputes.rb
+++ b/lib/adyen/services/disputes.rb
@@ -5,7 +5,7 @@ module Adyen
 
     DEFAULT_VERSION = 30
     def initialize(client, version = DEFAULT_VERSION)
-      super(client, version, 'Disputes')
+      super(client, version, 'DisputesService')
     end
 
     def accept_dispute(request, headers: {})


### PR DESCRIPTION
In the Adyen Disputes API, there is a naming bug. This will be resolved so we can build the Disputes API.